### PR TITLE
fix: Lambda Web Adapterアーキテクチャ不一致によるInternal Server Errorの修正

### DIFF
--- a/deploy/push_to_ecr.sh
+++ b/deploy/push_to_ecr.sh
@@ -59,8 +59,8 @@ build_and_push_service() {
     fi
     
     # Build Docker image
-    echo -e "${YELLOW}🔨 Building ${service} Docker image...${NC}"
-    docker build -f ${service}_app/Dockerfile -t ${repo_name}:latest .
+    echo -e "${YELLOW}🔨 Building ${service} Docker image for linux/amd64...${NC}"
+    docker build --platform linux/amd64 -f ${service}_app/Dockerfile -t ${repo_name}:latest .
     
     if [ $? -ne 0 ]; then
         echo -e "${RED}❌ Docker build failed for ${service}${NC}"


### PR DESCRIPTION
## 📌 概要

Dockerビルドコマンドに `--platform linux/amd64` フラグを追加し、Lambda x86_64 アーキテクチャとの互換性を確保しました。

## 🔍 原因

ホストアーキテクチャ（M1/M2 Macの場合arm64）でビルドされたイメージがLambdaの x86_64 環境で実行されることで、Lambda Web Adapterの `exec format error` が発生していました。

## ✅ 修正内容

- `deploy/push_to_ecr.sh` の Docker ビルドコマンドに `--platform linux/amd64` を追加
- これにより、常に x86_64 アーキテクチャ用のイメージがビルドされるようになります

Fixes #5

Generated with [Claude Code](https://claude.ai/code)